### PR TITLE
Remove @ufl.edu requirement

### DIFF
--- a/client/src/auth/Register.js
+++ b/client/src/auth/Register.js
@@ -220,7 +220,7 @@ class Register extends Component {
                                         invalid: errors.email,
                                     })}
                                 />
-                                <label htmlFor="email">Email (registered UF email)</label>
+                                <label htmlFor="email">Email</label>
                                 <span className="red-text">{errors.email}</span>
                             </div>
                             <div className="input-field col s12">

--- a/server/validate/register.js
+++ b/server/validate/register.js
@@ -54,8 +54,6 @@ module.exports = function validateRegiserInput(data) {
         errors.email = "Email field required!";
     } else if (!Validator.isEmail(data.email)) {
         errors.email = "Email is invalid!";
-    } else if (data.email.split("@")[1] !== "ufl.edu") {
-        errors.email = "Email requires @ufl.edu domain!";
     } else if (!Validator.isLength(data.email, {min: 1, max: 60 })) {
         errors.email = "Email cannot exceed 60 characters!";
     }


### PR DESCRIPTION
Removes the need to have an @ufl.edu email for registration. Since account validation is only handled in the dashboard by an admin, it isn't necessary to have this requirement (as someone could use a random @ufl.edu email anyway). However, if a "confirm email" feature is implemented in the future, it might make more sense to include this requirement.